### PR TITLE
Feature/doc editor translation matching

### DIFF
--- a/src/assets/sass/components/_sidebar.scss
+++ b/src/assets/sass/components/_sidebar.scss
@@ -57,6 +57,9 @@
         }
 
       }
+      #translations {
+        margin-bottom: 200px;
+      }
     }
   }
 }

--- a/src/components/project/documents/editor/Editor.vue
+++ b/src/components/project/documents/editor/Editor.vue
@@ -147,36 +147,32 @@ export default {
   },
   methods: {
     contentChange (newContent, oldContent) {
-      console.log('content change')
-      console.log({ newContent, oldContent })
       let newContentBlocks = newContent.split('\n\n')
       let oldContentBlocks = oldContent.split('\n\n')
       let cursorStart = this.simplemde.codemirror.getCursor('start')
       let cursorEnd = this.simplemde.codemirror.getCursor('end')
       let baseLanguage = this.getProjectById(this.projectId).baseLanguage
-      console.log(cursorEnd)
       if (cursorEnd.line === cursorStart.line) {
         // Same line
         if (newContentBlocks.length > oldContentBlocks.length) {
-          // We've added a new line
-          console.log('adding new line ', cursorStart.line / 2)
+          // We've added a new line/s
+          let numberToAdd = newContentBlocks.length - oldContentBlocks.length
           this.translations.forEach(translation => {
             if (translation.language !== baseLanguage) {
-              translation.blocks.splice(cursorStart.line / 2, 0, '')
+              for (let i = 0; i < numberToAdd; i++) {
+                translation.blocks.splice(Math.ceil(cursorStart.line / 2), 0, '')
+              }
             }
           })
-          console.log(this.translations)
         } else if (newContentBlocks.length < oldContentBlocks.length) {
-          // We've removed a line
-          console.log('removing line ', cursorStart.line / 2)
+          // We've removed a line (only need to remove one here because of the start and end lines matching)
+          let numberToRemove = oldContentBlocks.length - newContentBlocks.length
           this.translations.forEach(translation => {
             if (translation.language !== baseLanguage) {
-              translation.blocks.splice(cursorStart.line / 2, 1)
+              translation.blocks.splice(Math.ceil(cursorStart.line / 2), numberToRemove)
             }
           })
         }
-      } else {
-
       }
     },
     setupTranslations () {

--- a/src/components/translations/DirectoryCard.vue
+++ b/src/components/translations/DirectoryCard.vue
@@ -53,6 +53,7 @@
                     </fa-icon>
                   </b-input-group-addon>
                   <b-form-textarea
+                    @input="requiresSave = true"
                     v-model.trim="currentTranslationTitle.title"
                     :placeholder="$t('translationWorkflow.translations.titlePlaceholder')"
                     :class="rtl ? 'text-rtl' : ''">
@@ -146,6 +147,7 @@ export default {
       file: null,
       editTitle: false,
       isOpen: false,
+      requiresSave: false,
       currentTranslationTitle: {
         title: '',
         language: ''
@@ -160,10 +162,11 @@ export default {
     isTranslated (type) {
       switch (type) {
         case 'title':
-          if (this.currentBaseTitle.revision !== this.currentTranslationTitle.revision || this.currentTranslationTitle.title === '') {
+          if (this.currentBaseTitle.revision !== this.currentTranslationTitle.revision) {
+            return false
+          } else if (this.requiresSave || this.currentTranslationTitle.title === '') {
             return false
           }
-
           return true
         case 'file':
 
@@ -183,6 +186,7 @@ export default {
         title: translation.title,
         revision: this.currentBaseTitle.revision
       }).then(() => {
+        this.requiresSave = false
         translation.revision += 1
         this.$notifications.notify(
           {
@@ -265,7 +269,10 @@ export default {
       return this.$store.state.translations.baseLanguage
     },
     currentBaseTitle () {
-      return this.directory.getTitleByLangCode(this.baseLanguage.value.code)
+      if (this.baseLanguage) {
+        return this.directory.getTitleByLangCode(this.baseLanguage.value.code)
+      }
+      return {}
     }
   }
 }

--- a/src/vuex/modules/document/index.js
+++ b/src/vuex/modules/document/index.js
@@ -9,7 +9,9 @@ const documents = {
     documents: [],
     total: 0,
     currentBaseDocument: null,
-    currentTranslatingDocument: null
+    currentTranslatingDocument: null,
+    currentEditDocument: null,
+    editTranslations: []
   },
   mutations: {
     SET_ALL_DOCUMENTS: (state, { response }) => {
@@ -28,12 +30,23 @@ const documents = {
         state.currentTranslatingDocument = new Translation(response.data)
       }
     },
+    SET_EDIT_CURRENT_DOCUMENT: (state, { response }) => {
+      if (response.data) {
+        state.currentEditDocument = new Document(response.data)
+      }
+    },
     RESET_DOCUMENT: (state, isBase) => {
       if (isBase) {
         state.currentBaseDocument = null
       } else {
         state.currentTranslatingDocument = null
       }
+    },
+    RESET_CURRENT_DOC_TRANSLATIONS: (state) => {
+      state.editTranslations = []
+    },
+    ADD_CURRENT_DOC_TRANSlATION: (state, { response }) => {
+      state.editTranslations.push(new Translation(response.data))
     }
   },
   actions: {
@@ -45,6 +58,26 @@ const documents = {
           commit('SET_MESSAGE', { message: err })
           throw err
         })
+    },
+    GET_DOCUMENT_TRANSLATIONS: function ({commit, state}, {documentId, projectId}) {
+      return axios.get('/projects/' + projectId + '/documents/')
+        .then((response) => {
+          console.log(response.data.data.find(doc => doc.id === documentId))
+          commit('SET_EDIT_CURRENT_DOCUMENT', { response: {data: response.data.data.find(doc => doc.id === documentId)} })
+        }).catch(err => {
+          commit('SET_MESSAGE', { message: err })
+          throw err
+        })
+    },
+    GET_CURRENT_DOCUMENT_TRANSLATIONS: function ({commit, state}, {projectId}) {
+      if (state.currentEditDocument) {
+        return fetchTranslations({ documents: state.currentEditDocument.translations, projectId, commit })
+        .catch(err => {
+          commit('SET_MESSAGE', { message: err })
+          throw err
+        })
+      }
+      return false
     },
     GET_DOCUMENT_BY_ID_LANG: function ({commit}, {language, documentId, isBase}) {
       return axios.get('documents/' + documentId + '/translations/' + language)
@@ -94,6 +127,18 @@ const documents = {
       }
     }
   }
+}
+
+const fetchTranslations = ({ documents, projectId, commit }) => {
+  let promises = []
+  commit('RESET_CURRENT_DOC_TRANSLATIONS')
+  documents.forEach(doc => {
+    promises.push(axios.get('documents/' + doc.documentId + '/translations/' + doc.language)
+      .then((response) => {
+        commit('ADD_CURRENT_DOC_TRANSlATION', { response: response.data })
+      }))
+  })
+  return Promise.all(promises)
 }
 
 export default documents


### PR DESCRIPTION
**Translation Matching on the document edit side.**
When we edit a document we need to make sure that we are updating the translations for that document so they match when we come to edit them.

Fixes for:
- Translations not appearing in the sidebar
- Green tick on translating a directory title (was showing at the wrong point)